### PR TITLE
Fix json request body is read correctly

### DIFF
--- a/apitoolkit_pyramid/__init__.py
+++ b/apitoolkit_pyramid/__init__.py
@@ -96,7 +96,7 @@ class APIToolkit(object):
         content_type = request.headers.get('Content-Type', '')
 
         if content_type == 'application/json':
-            request_body = json.loads(request.body.decode('utf-8'))
+            request_body = request.json_body
         if content_type == 'text/plain':
             request_body = request.body.decode('utf-8')
         if content_type == 'application/x-www-form-urlencoded' or 'multipart/form-data' in content_type:
@@ -111,7 +111,7 @@ class APIToolkit(object):
             print("APIToolkit: after request")
         end_time = time.perf_counter_ns()
         url_path = request.matched_route.pattern if request.matched_route is not None else request.path
-        path_params = request.matchdict     
+        path_params = request.matchdict
         duration = (end_time - start_time)
         status_code = response.status_code
         request_body = json.dumps(request_body)


### PR DESCRIPTION
Currently json request bodys are not making it to apitoolkit log. Pyramid provides [`request.json_body`](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/webob.html#dealing-with-a-json-encoded-request-body) for easy access.

## How to test

Generate a request with a json request body. I confirmed it works after the change.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [x] You are **NOT** deprecating/removing a feature.
