### PR TITLE
Add route whitelist option and extend ini config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Add your APIToolkit API key `APITOOLKIT_KEY` to your `development.ini` or `produ
 APITOOLKIT_KEY = "<YOUR_API_KEY>"
 ```
 
+When using ini files separate mulitple values with comma.
+
+```ini
+APITOOLKIT_REDACT_HEADERS = X-Secret1,X-Secret2
+```
+
 Then add apitoolkit pyramid tween in your server's config:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ APITOOLKIT_REDACT_HEADERS: `optional` List of headers to redact in captured requ
 APITOOLKIT_DEBUG: `optional` Flag to enable debug mode.
 APITOOLKIT_REDACT_REQ_BODY: `optional` List of fields to redact in request bodies.
 APITOOLKIT_REDACT_RES_BODY: `optional` List of fields to redact in response bodies.
+APITOOLKIT_ROUTES_WHITELIST: `optional` List of routes prefixes that should be captured.
 APITOOLKIT_SERVICE_VERSION: `optional` Version of the service (helps in monitoring different versions of your deployments).
 APITOOLKIT_TAGS: `optional` Tags associated with the service.
 
@@ -81,6 +82,18 @@ The choice of JSONPath was selected to allow you have great flexibility in desci
 Also note that these list of items to be redacted will be aplied to all endpoint requests and responses on your server.
 To learn more about jsonpath to help form your queries, please take a look at this cheatsheet:
 [https://lzone.de/cheat-sheet/JSONPath](https://lzone.de/cheat-sheet/JSONPath)
+
+## Routes Whitelist
+
+If you only want to capture specific app routes you can configure prefixes that need be matched.
+
+```python
+settings = {
+"APITOOLKIT_ROUTES_WHITELIST": ["/api/first", "/api/second"],
+}
+```
+
+This will only capture requests that are incoming to your app with these prefixes, e.a. `/api/first/customer/1` but not `/api/health`.
 
 ## Debugging
 

--- a/apitoolkit_pyramid/__init__.py
+++ b/apitoolkit_pyramid/__init__.py
@@ -13,25 +13,31 @@ from google.oauth2 import service_account
 from jsonpath_ng import parse
 from pyramid.request import Request
 
+OPTIONAL_SETTINGS = (
+    # var in class, environment name, type, default value
+    ('debug', 'APITOOLKIT_DEBUG', bool, False),
+    ('redact_headers', 'APITOOLKIT_REDACT_HEADERS', list, []),
+    ('redact_request_body', 'APITOOLKIT_REDACT_REQ_BODY', list, []),
+    ('redact_response_body', 'APITOOLKIT_REDACT_RES_BODY', list, []),
+    ('routes_whitelist', 'APITOOLKIT_ROUTES_WHITELIST', list, []),
+    ('service_version', 'APITOOLKIT_SERVICE_VERSION', str, None),
+    ('tags', 'APITOOLKIT_TAGS', list, []),
+)
+
 
 class APIToolkit(object):
     def __init__(self, handler, registry):
         self.publisher = None
         self.topic_name = None
         self.meta = None
-        self.redact_headers = registry.settings.get('APITOOLKIT_REDACT_HEADERS', [])
-        self.debug = registry.settings.get('APITOOLKIT_DEBUG', False)
-        self.redact_request_body = registry.settings.get('APITOOLKIT_REDACT_REQ_BODY', [])
-        self.redact_response_body = registry.settings.get('APITOOLKIT_REDACT_RES_BODY', [])
-        self.routes_whitelist = registry.settings.get('APITOOLKIT_ROUTES_WHITELIST', [])
         self.get_response = handler
-
-        self.service_version = registry.settings.get("APITOOLKIT_SERVICE_VERSION", None)
-        self.tags =registry.settings.get("APITOOLKIT_TAGS", [])
 
         api_key = registry.settings.get('APITOOLKIT_KEY')
         root_url = registry.settings.get('APITOOLKIT_ROOT_URL',
                            "https://app.apitoolkit.io")
+
+        for var_name, env_id, _type, default in OPTIONAL_SETTINGS:
+            self.prepare_optional_settings(var_name, registry.settings.get(env_id), _type, default)
 
         response = requests.get(url=root_url + "/api/client_metadata",
                                 headers={"Authorization": f"Bearer {api_key}"})
@@ -46,6 +52,16 @@ class APIToolkit(object):
             topic=data['topic_id'],
         )
         self.meta = data
+
+    def prepare_optional_settings(self, var_name, value, _type, default):
+        if _type in (bool, str):
+            setattr(self, var_name, value or default)
+        elif _type is list:
+            # env value can directly be a list or when given via ini file a comma separated string
+            try:
+                setattr(self, var_name, value.split(','))
+            except AttributeError:
+                setattr(self, var_name, value or [])
 
     def getInfo(self):
         return {"project_id": self.meta["project_id"], "service_version": self.service_version, "tags": self.tags}


### PR DESCRIPTION
<!-- Thank you for contributing to APIToolkit! -->

<!-- Briefly describe what your PR does here as much as you can. -->

This adds the option `APITOOLKIT_ROUTES_WHITELIST` which allows to capture specific routes only. It will return early from the tween when the route(s) is not matched.

For using this I noticed that to use multiple option values from ini files the option initialization needs to be extended. As from ini setup only string values are returned a `split(',')` is used to create a list object.  
As this also effects other list options I tried to generalize the setup.

Are you open for such an extension/change?

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

Configure the new option and note that non-matching requests are not captured anymore.  
Use multi value options in ini file.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes (or request one from the team).
- [x] You are **NOT** deprecating/removing a feature.
