### PR TITLE
Add option to ignore HTTP response codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,17 @@ You can add more configurations in your settings to customize behavior, such as 
 
 `APITOOLKIT_KEY`: `required` API key for accessing the APIToolkit service
 
-`APITOOLKIT_REDACT_HEADERS`: `optional` List of headers to redact in captured requests. 
+`APITOOLKIT_REDACT_HEADERS`: `optional` List of headers to redact in captured requests.
 
-`APITOOLKIT_DEBUG`: `optional` Flag to enable debug mode. 
+`APITOOLKIT_DEBUG`: `optional` Flag to enable debug mode.
 
-`APITOOLKIT_REDACT_REQ_BODY`: `optional` List of fields to redact in request bodies. 
+`APITOOLKIT_REDACT_REQ_BODY`: `optional` List of fields to redact in request bodies.
 
-`APITOOLKIT_REDACT_RES_BODY`: `optional` List of fields to redact in response bodies. 
+`APITOOLKIT_REDACT_RES_BODY`: `optional` List of fields to redact in response bodies.
 
 `APITOOLKIT_ROUTES_WHITELIST`: `optional` List of routes prefixes that should be captured.
+
+`APITOOLKIT_IGNORE_HTTP_CODES`: `optional` List of HTTP status codes that should NOT be captured.
 
 `APITOOLKIT_SERVICE_VERSION`: `optional` Version of the service (helps in monitoring different versions of your deployments).
 
@@ -107,6 +109,16 @@ settings = {
 ```
 
 This will only capture requests that are incoming to your app with these prefixes, e.a. `/api/first/customer/1` but not `/api/health`.
+
+## Ignore HTTP status codes
+
+You can exclude HTTP response status codes that you're not interested in or that are spamming your log.
+
+```python
+settings = {
+"APITOOLKIT_IGNORE_HTTP_CODES": [404, 429],
+}
+```
 
 ## Debugging
 


### PR DESCRIPTION
<!-- Thank you for contributing to APIToolkit! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Add a new option `APITOOLKIT_IGNORE_HTTP_CODES` to exclude specific response codes that should not be logged.  
(Our use case is `HTTP 429 Too Many Requests` that is used for rate limiting.)

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

Define one or more status codes using the `APITOOLKIT_IGNORE_HTTP_CODES` config and observe that they are not logged.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes (or request one from the team).
- [x] You are **NOT** deprecating/removing a feature.
